### PR TITLE
Add empty throw() to void *TBufListEntry::operator new().

### DIFF
--- a/tvision/buffers.h
+++ b/tvision/buffers.h
@@ -56,7 +56,7 @@ private:
      * the allocation is returned; otherwise, abort() is called. Operator
      * new() is a friend function of TBufListEntry.
      */
-    void *operator new( size_t sz );
+    void *operator new( size_t sz ) throw();
     /**
      * Frees the allocation block from the heap. If the safety pool is
      * exhausted, @ref TVMemMgr::resizeSafetyPool is called.

--- a/tvision/new.cc
+++ b/tvision/new.cc
@@ -43,7 +43,7 @@ void *TBufListEntry::operator new( size_t sz, size_t extra )
     return malloc( sz + extra*sizeof( unsigned ) );
 }
 
-void *TBufListEntry::operator new( size_t )
+void *TBufListEntry::operator new( size_t ) throw()
 {
     return NULL;
 }


### PR DESCRIPTION
Solve compile error on g++ 4.8.4.
Tested on g++ 8.1.1 that still is possible to compile tvision with
-fno-exceptions -fno-rtti.